### PR TITLE
add customizable drawDebug() to lambdaView component

### DIFF
--- a/src/components/LambdaView.cpp
+++ b/src/components/LambdaView.cpp
@@ -24,6 +24,11 @@ void LambdaView::setDrawFunction(std::function<void(void)> _func)
 	drawFunc = _func;
 }
 
+void LambdaView::setDrawDebugFunction(std::function<void(void)> _func)
+{
+	drawDebugFunc = _func;
+}
+
 void LambdaView::setUpdateFunction(std::function<void(float)> _func)
 {
 	updateFunc = _func;
@@ -53,6 +58,13 @@ void LambdaView::draw()
 {
 	if (drawFunc) {
 		drawFunc();
+	}
+}
+
+void LambdaView::drawDebug()
+{
+	if (drawDebugFunc) {
+		drawDebugFunc();
 	}
 }
 

--- a/src/components/LambdaView.h
+++ b/src/components/LambdaView.h
@@ -20,6 +20,7 @@ class LambdaView : public Node
 public:
 	LambdaView(const string& name="");
 	void setDrawFunction(std::function<void(void)> _func);
+	void setDrawDebugFunction(std::function<void(void)> _func);
 	void setUpdateFunction(std::function<void(float)> _func);
 	void setTouchDownFunction(std::function<void(ofxInterface::TouchEvent&)> _func);
 	void setTouchMoveFunction(std::function<void(ofxInterface::TouchEvent&)> _func);
@@ -27,10 +28,12 @@ public:
 	void setContainsFunction(std::function<bool(const ofVec3f& global)> _func);
 	void update(float dt);
 	void draw();
+	void drawDebug();
 	bool contains(const ofVec3f& global);
 	
 private:
 	std::function<void(void)> drawFunc;
+	std::function<void(void)> drawDebugFunc = [&](){Node::drawDebug();};
 	std::function<void(float)> updateFunc;
 	std::function<void(ofxInterface::TouchEvent&)> touchDownFunc;
 	std::function<void(ofxInterface::TouchEvent&)> touchMoveFunc;


### PR DESCRIPTION
Hey just added a customisable drawDebug() to this very handy class. By default it provides the standard Node::drawDebug() functionality but it allows you to override it.